### PR TITLE
Check for 204 before decoding json

### DIFF
--- a/hyperwallet/utils/apiclient.py
+++ b/hyperwallet/utils/apiclient.py
@@ -107,7 +107,9 @@ class ApiClient(object):
         except:
             return body
 
-        if response.ok:
+        if response.status_code == 204:
+            body = {'count': 0, 'data': []}
+        elif response.ok:
             body = response.json()
         else:
             if (not response.ok and


### PR DESCRIPTION
The Hyperwallet API docs do not indicate a 204 response on resource index endpoints but I'm certainly getting them. This SDK which I purloined from them doesn't check for 204. Now it does.