### PR TITLE
Make this easier to work with

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 *.pyc
 dist
 *.egg-info
+.venv
+.eggs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist
 *.egg-info
 .venv
 .eggs
+htmlcov
+.coverage
+.tox

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+*.pyc
+dist
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -7,9 +7,41 @@ make a pull request against the official repo.
 
 ---
 
-## Sample code
+# Basics
 
-Create `hw.py`:
+## Setting up
+
+Development & Testing is done within a virtualenv
+
+```
+virtualenv .venv
+source .venv/bin/activate
+```
+
+## Running tests
+
+```
+python setup.py test
+```
+
+## Building
+
+```
+python setup.py build
+```
+
+## Installing
+
+```
+python setup.py install
+```
+
+## Usage
+
+<details>
+<summary>Expand ...</summary>
+
+### Create `hw.py`
 
 ```
 import json
@@ -82,10 +114,12 @@ list_all_users()
 
 ```
 
-## How to use
+### Run the code
 
 ```
 pip install https://github.com/kalohq/hyperwallet-sdk/archive/v0.3.6.zip
 export HYPERWALLET_DEBUG=1  # log all API requests/responses to stdout
 python hw.py
 ```
+</details>
+

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ Development & Testing is done within a virtualenv
 ```
 virtualenv .venv
 source .venv/bin/activate
+pip install -r dev-requirements.txt
 ```
 
 ## Running tests
 
 ```
-python setup.py test
+python setup.py test && tox && pycodestyle hyperwallet
 ```
 
 ## Building
@@ -34,6 +35,14 @@ python setup.py build
 
 ```
 python setup.py install
+```
+
+## Coverage
+
+```
+coverage run setup.py test
+coverage html
+coverage report
 ```
 
 ## Usage

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,5 @@
+mock==3.0.5
+pytest==4.6.3
+requests==2.22.0
+requests-toolbelt==0.9.1
+unittest2==1.1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,8 @@
+-r requirements.txt
 mock==3.0.5
 pytest==4.6.3
-requests==2.22.0
-requests-toolbelt==0.9.1
 unittest2==1.1.0
+coverage==4.5.3
+nose==1.3.7
+pycodestyle==2.5.0
+tox==3.12.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     version = extract_metaitem('version'),
     license = extract_metaitem('license'),
     description = extract_metaitem('description'),
-    long_description = (read('README.rst') + '\n\n' +
+    long_description = (read('README.md') + '\n\n' +
                         read('CHANGELOG.rst')),
     maintainer = extract_metaitem('author'),
     maintainer_email = extract_metaitem('email'),

--- a/setup.py
+++ b/setup.py
@@ -9,18 +9,27 @@ from setuptools import setup, find_packages
 
 ground = os.path.abspath(os.path.dirname(__file__))
 
+
 def read(filename):
     with codecs.open(os.path.join(ground, filename), 'rb', 'utf-8') as file:
         return file.read()
 
+
 metadata = read(os.path.join(ground, 'hyperwallet', '__init__.py'))
+
 
 def extract_metaitem(meta):
     # swiped from https://hynek.me 's attr package
-    meta_match = re.search(r"""^__{meta}__\s+=\s+['\"]([^'\"]*)['\"]""".format(meta=meta), metadata, re.MULTILINE)
+    meta_match = re.search(
+        r"""^__{meta}__\s+=\s+['\"]([^'\"]*)['\"]""".format(meta=meta),
+        metadata,
+        re.MULTILINE
+    )
+
     if meta_match:
         return meta_match.group(1)
     raise RuntimeError('Unable to find __{meta}__ string.'.format(meta=meta))
+
 
 setup(
     name = 'hyperwallet-sdk',
@@ -30,8 +39,10 @@ setup(
     version = extract_metaitem('version'),
     license = extract_metaitem('license'),
     description = extract_metaitem('description'),
-    long_description = (read('README.md') + '\n\n' +
-                        read('CHANGELOG.rst')),
+    long_description = (
+        read('README.md') + '\n\n' +
+        read('CHANGELOG.rst')
+    ),
     maintainer = extract_metaitem('author'),
     maintainer_email = extract_metaitem('email'),
     packages = find_packages(exclude = ('tests', 'doc')),
@@ -47,6 +58,9 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]


### PR DESCRIPTION
setup.py was broken, it referenced a file that did not exist

None of the dev dependencies were written down

Building the thing with `python3 setup.py build` littered my IDE with files I could commit.

This is one quality of life PR which is easy. Yes it could go further, but it chooses not to as part of go-forward engineering strategy outlined `June 2019`